### PR TITLE
Users と Videos のDB設計を変更

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,7 @@
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /videos/{video} {
-      allow read, write: if request.auth.uid != null;
+    match /{document=**} {
+      allow read, write;
     }
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,29 @@
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write;
+    function isAuthenticated() {
+      return request.auth.uid != null;
+    }
+
+    function isUserAuthenticated(userId) {
+      return request.auth.uid == userId;
+    }
+
+    function isAdmin() {
+      return exists(/databases/$(database)/documents/admins/$(request.auth.uid));
+    }
+
+    match /users/{userId} {
+      allow get: if isAuthenticated();
+      allow create, update, delete: if isUserAuthenticated(userId) || isAdmin();
+
+      match /videos/{videoId} {
+        allow read: if isAuthenticated();
+        allow create, update, delete: if isUserAuthenticated(userId) || isAdmin();
+      }
+    }
+    
+    match /videos/{video} {
+    	allow read: if isAuthenticated();
     }
   }
 }

--- a/functions/copyVideoMetadata.js
+++ b/functions/copyVideoMetadata.js
@@ -1,0 +1,30 @@
+const functions = require('firebase-functions');
+const serviceAccount = require('./config/service_account.json');
+const admin = require('firebase-admin');
+try {
+  admin.initializeApp({
+    credential: admin.credential.cert(serviceAccount),
+    databaseURL: "https://fir-reacty-videos.firebaseio.com"
+  });
+  admin.firestore().settings({timestampsInSnapshots: true});
+} catch (error) {
+  console.log(error);
+}
+const firestore = admin.firestore();
+
+exports.onUsersVideoCreate = functions.firestore.document('users/{userId}/videos/{videoId}').onCreate(async (snapshot, context) => {
+  await copyToRootWithUsersVideoSnapshot(snapshot, context);
+});
+
+exports.onUsersVideoUpdate = functions.firestore.document('users/{userId}/videos/{videoId}').onUpdate(async (change, context) => {
+  await copyToRootWithUsersVideoSnapshot(change.after, context);
+});
+
+async function copyToRootWithUsersVideoSnapshot(snapshot, context) {
+  const userId = context.params.userId;
+  const videoId = context.params.videoId;
+  const video = snapshot.data();
+  video.userRef = firestore.collection('users').doc(userId);
+
+  await firestore.collection('videos').doc(videoId).set(video, { merge: true });
+}

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,3 +11,17 @@ if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'transcodeVideo'
 if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'saveUser') {
   exports.saveUser = require('./saveUser').saveUser;
 }
+
+/*
+* Triggers when was created new video data, video data is copied Firestore
+*/
+if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'onUsersVideoCreate') {
+  exports.onUsersVideoCreate = require('./copyVideoMetadata').onUsersVideoCreate;
+}
+
+/*
+* Triggers when was updated new video data, video data is copied Firestore
+*/
+if (!process.env.FUNCTION_NAME || process.env.FUNCTION_NAME === 'onUsersVideoUpdate') {
+  exports.onUsersVideoUpdate = require('./copyVideoMetadata').onUsersVideoUpdate;
+}

--- a/functions/transcodeVideo.js
+++ b/functions/transcodeVideo.js
@@ -31,6 +31,7 @@ async function saveVideoMetadata(userToken, metadata) {
   const decodedToken = await admin.auth().verifyIdToken(userToken);
   const user_id = decodedToken.uid;
   const videoRef = admin.firestore().doc(`users/${user_id}`).collection('videos').doc();
+  metadata = Object.assign(metadata, { uid: videoRef.id });
   
   await videoRef.set(metadata, { merge: true });
 }

--- a/functions/transcodeVideo.js
+++ b/functions/transcodeVideo.js
@@ -75,7 +75,8 @@ exports.transcodeVideo = functions.storage.object().onFinalize(async object => {
       }
     });
 
-    let metadata = await videoFile.getMetadata();
+    let transcodedVideoFile = await bucket.file(targetStorageFilePath);
+    let metadata = await transcodedVideoFile.getMetadata();
     const downloadURL = `https://firebasestorage.googleapis.com/v0/b/${bucketName}/o/${encodeURIComponent(targetTranscodedFilePath)}?alt=media&token=${token}`;
     metadata = Object.assign(metadata[0], {downloadURL: downloadURL});
     const userToken = object.metadata.idToken;

--- a/src/components/VideoUpload.js
+++ b/src/components/VideoUpload.js
@@ -38,7 +38,7 @@ class Upload extends Component {
         let metadata = _.omitBy(fileSnapshot.metadata, _.isEmpty);
         metadata = Object.assign(metadata, {downloadURL: downloadURL});
 
-        this.saveVideoMetadata(metadata);
+        await this.saveVideoMetadata(metadata);
       }
 
       if (fileSnapshot.state === 'success') {
@@ -58,9 +58,11 @@ class Upload extends Component {
     }
   }
 
-  saveVideoMetadata(metadata) {
-    const collection = firebase.firestore().collection('videos');
-    return collection.add(metadata);
+  async saveVideoMetadata(metadata) {
+    const user_id = firebase.auth().currentUser.uid;
+    const videoRef = firebase.firestore().doc(`users/${user_id}`).collection('videos').doc();
+
+    await videoRef.set(metadata, { merge: true });
   }
 
   render() {

--- a/src/components/VideoUpload.js
+++ b/src/components/VideoUpload.js
@@ -31,7 +31,6 @@ class Upload extends Component {
       const videoStorageRef = firebase.storage().ref(filePath);
       const idToken = await firebase.auth().currentUser.getIdToken(true);
       const metadataForStorage = {
-        name: `${video.name}_sample`,
         customMetadata: {
           idToken: idToken
         }
@@ -68,6 +67,7 @@ class Upload extends Component {
   async saveVideoMetadata(metadata) {
     const user_id = firebase.auth().currentUser.uid;
     const videoRef = firebase.firestore().doc(`users/${user_id}`).collection('videos').doc();
+    metadata = Object.assign(metadata, { uid: videoRef.id });
 
     await videoRef.set(metadata, { merge: true });
   }

--- a/src/components/VideoUpload.js
+++ b/src/components/VideoUpload.js
@@ -29,16 +29,23 @@ class Upload extends Component {
     try {
       const filePath = `videos/${firebase.auth().currentUser.uid}/${video.name}`;
       const videoStorageRef = firebase.storage().ref(filePath);
-      const fileSnapshot = await videoStorageRef.put(video);
+      const idToken = await firebase.auth().currentUser.getIdToken(true);
+      const metadataForStorage = {
+        name: `${video.name}_sample`,
+        customMetadata: {
+          idToken: idToken
+        }
+      }
+      const fileSnapshot = await videoStorageRef.put(video, metadataForStorage);
 
       // mp4以外の動画は、Cloud Functions上で、トランスコードした後に
       // メタデータを Firestore に保存する
       if (video.type === 'video/mp4') {
         const downloadURL = await videoStorageRef.getDownloadURL();
-        let metadata = _.omitBy(fileSnapshot.metadata, _.isEmpty);
-        metadata = Object.assign(metadata, {downloadURL: downloadURL});
+        let metadataForFirestore = _.omitBy(fileSnapshot.metadata, _.isEmpty);
+        metadataForFirestore = Object.assign(metadataForFirestore, {downloadURL: downloadURL});
 
-        await this.saveVideoMetadata(metadata);
+        await this.saveVideoMetadata(metadataForFirestore);
       }
 
       if (fileSnapshot.state === 'success') {


### PR DESCRIPTION
## 目的
- Users と Videos に参照をもたせる

## 構成

![user_and_videos_data_modeling_in_firestore](https://user-images.githubusercontent.com/7115171/46325420-1a334700-c633-11e8-89bb-df79762c8f25.png)

## 今回の変更処理の流れ

1. 画面からのアップロード時に、UsersドキュメントにVideosサブコレクションとVideosドキュメントをFirestoreに保存
2. Firestoreへの Create, Update をトリガーに、`Videos`コレクション以下に`Video`ドキュメントを格納

## `Videos`コレクションによるデータの冗長化について

- Firestore のクエリの都合上、Usersコレクション以下とは別に、コレクションを作成することで、`Users`コレクションを経由せずに、`Videos`のデータを取得したいとうユースケースに対応するため

## セキュリティルールの変更について

### User ドキュメント及び Users以下のVideo ドキュメントに対する権限
- 読み取り = 認証済みユーザーのみ
- 書き込み = 書き込みをしたユーザー自身または、管理者ユーザーのみ

### Videos コレクションに対する権限
- 読み取り = 認証済みユーザーのみ
- 書き込み = ルール未設定のため、すべてのユーザーは書き込み不可